### PR TITLE
fix: docs: convert leading // comments to Doxygen style

### DIFF
--- a/Engine/Core/Application.cpp
+++ b/Engine/Core/Application.cpp
@@ -12,9 +12,11 @@
 
 namespace Thrive
 {
-	//Method		: Application::Application
-	//Parameters	: ()
-	//Description   : This will setup our application by getting the window ready, and the renderer ready. If in debug mode then console logging is turned on. 
+/**
+ * Method		: Application::Application
+ * Parameters	: ()
+ * Description   : This will setup our application by getting the window ready, and the renderer ready. If in debug mode then console logging is turned on. 
+ */
 	Application::Application ()
 	{
 		m_Window.InitWindow(); 
@@ -27,29 +29,37 @@ namespace Thrive
 			std::make_unique<ImGuiLayer>(m_Window.GetWindow())
 		);
 
-		// ===============
-		// + Debug Mode  +
-		// ===============
-		// - Turns on logging
-		// - Init the DearImGui layer. 
+/**
+ * ===============
+ * + Debug Mode  +
+ * ===============
+ * - Turns on logging
+ * - Init the DearImGui layer. 
+ */
 		#ifdef THRIVE_DEBUG
 				Log::Init();	
 		#endif
 	}
 	
-	//Currently not being used
+/**
+ * Currently not being used
+ */
 	Application::~Application ()
 	{
 
 	}
 
-	//Method		: Application::Run()
-	//Parameters	: ()
-	//Returns		: void
-	//Description   : This method will run our Application 
+/**
+ * Method		: Application::Run()
+ * Parameters	: ()
+ * Returns		: void
+ * Description   : This method will run our Application 
+ */
 	void Application::Run ()
 	{
-		//Game loop
+/**
+ * Game loop
+ */
 		while (m_Window.GetWindow().isOpen())
 		{
 			Time::Update();
@@ -64,10 +74,12 @@ namespace Thrive
 		}
 	}	
 
-	//Method		: Application::ProcessEvents()
-	//Parameters	:
-	//Returns		: void
-	//Description   : This method will call the dispatch events method. 
+/**
+ * Method		: Application::ProcessEvents()
+ * Parameters	:
+ * Returns		: void
+ * Description   : This method will call the dispatch events method. 
+ */
 	void Application::ProcessEvents()
 	{
 		m_Window.PollEvents([this](Event& e)
@@ -76,10 +88,12 @@ namespace Thrive
 			});
 	}
 
-	//Method		: Application::Update(float deltaTime)
-	//Parameters	: float deltaTime
-	//Returns		: void
-	//Description   : This method will update our layer, 
+/**
+ * Method		: Application::Update(float deltaTime)
+ * Parameters	: float deltaTime
+ * Returns		: void
+ * Description   : This method will update our layer, 
+ */
 	void Application::Update(float deltaTime)
 	{
 		for (auto& layer : m_LayerStack)
@@ -88,10 +102,12 @@ namespace Thrive
 		}
 	}
 
-	//Method		: Application::Render()
-	//Parameters	:
-	//Returns		: void
-	//Description   : This method will render our engine objects. 
+/**
+ * Method		: Application::Render()
+ * Parameters	:
+ * Returns		: void
+ * Description   : This method will render our engine objects. 
+ */
 	void Application::Render()
 	{
 		Renderer::BeginFrame();
@@ -122,10 +138,12 @@ namespace Thrive
 		Renderer::EndFrame();
 	}
 	
-	//Method		: Application::PushLayer
-	//Parameters	: (std::unique_ptr<Layer> layer)
-	//Returns		: void
-	//Description   : This method will push a new layer from our game to our layer stack
+/**
+ * Method		: Application::PushLayer
+ * Parameters	: (std::unique_ptr<Layer> layer)
+ * Returns		: void
+ * Description   : This method will push a new layer from our game to our layer stack
+ */
 	void Application::PushLayer(std::unique_ptr <Layer> layer)
 	{
 		m_LayerStack.PushLayer(std::move(layer));
@@ -134,11 +152,13 @@ namespace Thrive
 
 
 
-	//Method		: Application::DispatchEvent(Event& e)
-	//Parameters	: (Event& e)
-	//Returns		: void 
-	//Description   : This methods job is to take in a current event that needs to be ran and create an 
-	//					event dispatcher for that current event. 
+/**
+ * Method		: Application::DispatchEvent(Event& e)
+ * Parameters	: (Event& e)
+ * Returns		: void 
+ * Description   : This methods job is to take in a current event that needs to be ran and create an 
+ * 				event dispatcher for that current event. 
+ */
 	void Application::DispatchEvent (Event& e)
 	{
 		EventDispatcher dispatcher(e);
@@ -156,7 +176,9 @@ namespace Thrive
 			return true;
 		});
 		
-		// Send to layers
+/**
+ * Send to layers
+ */
 		for (auto it = m_LayerStack.rbegin(); it != m_LayerStack.rend(); ++it)
 		{
 			(*it)->OnEvent(e);

--- a/Engine/Core/Application.h
+++ b/Engine/Core/Application.h
@@ -20,8 +20,10 @@
 
 namespace Thrive
 {
-	//Class		 : Application
-	//Description: This is our application class. 
+/**
+ * Class		 : Application
+ * Description: This is our application class. 
+ */
 	class Application
 	{
 	public:
@@ -38,9 +40,13 @@ namespace Thrive
 		void PushLayer(std::unique_ptr <Layer> layer); 
 		void DispatchEvent(Event& e);
 	
-	//Class Variables 
+/**
+ * Class Variables 
+ */
 	private:
-		//delta time
+/**
+ * delta time
+ */
 		sf::Clock m_Clock;
 		Window m_Window;
 		LayerStack m_LayerStack; 

--- a/Engine/Core/ImGuiLayer.cpp
+++ b/Engine/Core/ImGuiLayer.cpp
@@ -16,10 +16,12 @@
 namespace Thrive
 {
 	
-	//Method		: void ImGuiLayer::OnAttach()
-	//Parameters	: ()
-	//Returns		: void
-	//Description   : This method will setup the ImGuiLayer
+/**
+ * Method		: void ImGuiLayer::OnAttach()
+ * Parameters	: ()
+ * Returns		: void
+ * Description   : This method will setup the ImGuiLayer
+ */
 	void ImGuiLayer::OnAttach()
 	{
 	
@@ -32,46 +34,56 @@ namespace Thrive
 		ImGui::SFML::Init(m_Window); 
 	}
 
-	//Method		: void ImGuiLayer::OnDetach()
-	//Parameters	: ()
-	//Returns		: void
-	//Description   : This method will destroy the ImGui elements
+/**
+ * Method		: void ImGuiLayer::OnDetach()
+ * Parameters	: ()
+ * Returns		: void
+ * Description   : This method will destroy the ImGui elements
+ */
 	void ImGuiLayer::OnDetach()
 	{
 		ImGui::SFML::Shutdown();
 		ImGui::DestroyContext();
 	}
 
-	//Method		: void ImGuiLayer::Begin(sf::RenderWindow& window, sf::Clock deltaClock)
-	//Parameters	: sf::RenderWindow& window, sf::Clock deltaClock
-	//Returns		: void
-	//Description   : This method is static. It take the current window and time, so it can update ImGui
+/**
+ * Method		: void ImGuiLayer::Begin(sf::RenderWindow& window, sf::Clock deltaClock)
+ * Parameters	: sf::RenderWindow& window, sf::Clock deltaClock
+ * Returns		: void
+ * Description   : This method is static. It take the current window and time, so it can update ImGui
+ */
 	void ImGuiLayer::Begin(sf::RenderWindow& window, sf::Clock deltaClock)
 	{
 		ImGui::SFML::Update(window, deltaClock.restart()); 
 	}
 
-	//Method		: void ImGuiLayer::End (sf::RenderWindow& window)
-	//Parameters	: sf::RenderWindow& window
-	//Returns		: void
-	//Description   : This method is static. It takes in the current window, so it can renderer the ImGUI UI
+/**
+ * Method		: void ImGuiLayer::End (sf::RenderWindow& window)
+ * Parameters	: sf::RenderWindow& window
+ * Returns		: void
+ * Description   : This method is static. It takes in the current window, so it can renderer the ImGUI UI
+ */
 	void ImGuiLayer::End(sf::RenderWindow& window)
 	{
 		ImGui::SFML::Render(window);
 	}
 
-	//Method		: void ImGuiLayer::OnUpdate(float dt)
-	//Parameters	: float dt
-	//Returns		: void
-	//Description   : This method currently does nothing 
+/**
+ * Method		: void ImGuiLayer::OnUpdate(float dt)
+ * Parameters	: float dt
+ * Returns		: void
+ * Description   : This method currently does nothing 
+ */
 	void ImGuiLayer::OnUpdate(float dt)
 	{
 		// Intentionally empty OR debug-only logic
 	}
 
-	/// <summary>
-	/// For Testing at the moment 
-	/// </summary>
+/**
+ * / <summary>
+ * / For Testing at the moment 
+ * / </summary>
+ */
 	void ImGuiLayer::OnImGuiRender()
 	{
 		// Example UI
@@ -81,9 +93,11 @@ namespace Thrive
 	}
 
 
-	/// <summary>
-	/// For Testing 
-	/// </summary>
+/**
+ * / <summary>
+ * / For Testing 
+ * / </summary>
+ */
 	void ImGuiLayer::DrawSpace()
 	{
 		ImGuiWindowFlags window_flags = ImGuiWindowFlags_NoDocking;

--- a/Engine/Core/ImGuiLayer.h
+++ b/Engine/Core/ImGuiLayer.h
@@ -8,13 +8,17 @@
 
 namespace Thrive
 {
-	//Class		 : ImGuiLayer
-	//Description: This class is a devired class from Layer. Layer can be found in the Layer.h file. 
+/**
+ * Class		 : ImGuiLayer
+ * Description: This class is a devired class from Layer. Layer can be found in the Layer.h file. 
+ */
 	class ImGuiLayer : public Layer
 	{
 		
 	public:
-		// This is used to set the m_Window to the current window. 
+/**
+ * This is used to set the m_Window to the current window. 
+ */
 		ImGuiLayer (sf::RenderWindow& window) : m_Window(window) {}
 
 		void OnAttach () override; 
@@ -22,7 +26,9 @@ namespace Thrive
 		void OnUpdate (float dt) override; 
 		void OnImGuiRender () override;
 
-		// Static methods
+/**
+ * Static methods
+ */
 	public:
 		static void Begin (sf::RenderWindow& window, sf::Clock deltaClock);
 		static void End (sf::RenderWindow& window);

--- a/Engine/Core/Layer.h
+++ b/Engine/Core/Layer.h
@@ -9,8 +9,10 @@
 
 namespace Thrive
 {
-	//Class		 : Layer 
-	//Description: This will be our base layer class. 
+/**
+ * Class		 : Layer 
+ * Description: This will be our base layer class. 
+ */
 	class Layer
 	{
 	public:

--- a/Engine/Core/LayerStack.cpp
+++ b/Engine/Core/LayerStack.cpp
@@ -8,10 +8,12 @@
 
 namespace Thrive
 {
-	//Method		: void LayerStack::PushLayer (LayerPtr layer)
-	//Parameters	: (LayerPtr layer)
-	//Returns		: void
-	//Description   : This method will add a layer to our layer stack. 
+/**
+ * Method		: void LayerStack::PushLayer (LayerPtr layer)
+ * Parameters	: (LayerPtr layer)
+ * Returns		: void
+ * Description   : This method will add a layer to our layer stack. 
+ */
 	void LayerStack::PushLayer (LayerPtr layer)
 	{
 		m_Layers.insert(m_Layers.begin() + m_LayerInsertIndex, std::move(layer));
@@ -20,10 +22,12 @@ namespace Thrive
 		m_Layers[m_LayerInsertIndex - 1] -> OnAttach(); 
 	}
 
-	//Method		: void LayerStack::PushOverlay(LayerPtr overlay)
-	//Parameters	: (LayerPtr overlay)
-	//Returns		: void
-	//Description   : This method will be used to push an overlay to our layerstack
+/**
+ * Method		: void LayerStack::PushOverlay(LayerPtr overlay)
+ * Parameters	: (LayerPtr overlay)
+ * Returns		: void
+ * Description   : This method will be used to push an overlay to our layerstack
+ */
 	void LayerStack::PushOverlay (LayerPtr overlay)
 	{
 		if (!overlay)
@@ -36,10 +40,12 @@ namespace Thrive
 	}
 
 
-	//Method		: void LayerStack::PopLayer()
-	//Parameters	: 
-	//Returns		: void
-	//Description   : This method will remove the last layer added to the layer stack. 
+/**
+ * Method		: void LayerStack::PopLayer()
+ * Parameters	: 
+ * Returns		: void
+ * Description   : This method will remove the last layer added to the layer stack. 
+ */
 	void LayerStack::PopLayer()
 	{
 		if (m_LayerInsertIndex > 0)
@@ -50,10 +56,12 @@ namespace Thrive
 		}
 	}
 
-	//Method		: void LayerStack::PopOverlay()
-	//Parameters	: 
-	//Returns		: void
-	//Description   : This method will remove an overlay 
+/**
+ * Method		: void LayerStack::PopOverlay()
+ * Parameters	: 
+ * Returns		: void
+ * Description   : This method will remove an overlay 
+ */
 	void LayerStack::PopOverlay()
 	{
 		if (m_LayerInsertIndex < m_Layers.size())

--- a/Engine/Core/LayerStack.h
+++ b/Engine/Core/LayerStack.h
@@ -8,8 +8,10 @@
 
 namespace Thrive
 {
-	//Class		 : LayerStack
-	//Description: This class will be a vector of layer unique pointers to a 
+/**
+ * Class		 : LayerStack
+ * Description: This class will be a vector of layer unique pointers to a 
+ */
 	class LayerStack {
 
 	public:
@@ -20,19 +22,27 @@ namespace Thrive
 		LayerStack() = default; 
 		~LayerStack() = default; 
 
-		//Add Layer
+/**
+ * Add Layer
+ */
 		void PushLayer (LayerPtr layer); 
 		void PushOverlay (LayerPtr overlay);
 
-		//Remove Layer
+/**
+ * Remove Layer
+ */
 		void PopLayer(); 
 		void PopOverlay();
 
-		//Iterators
+/**
+ * Iterators
+ */
 		auto begin() { return m_Layers.begin(); }
 		auto end() { return m_Layers.end(); }
 
-		//Reverse iteration (Import for Events) 
+/**
+ * Reverse iteration (Import for Events) 
+ */
 		auto rbegin() { return m_Layers.rbegin(); }
 		auto rend() { return m_Layers.rend(); }
 

--- a/Engine/Core/Window.cpp
+++ b/Engine/Core/Window.cpp
@@ -22,11 +22,13 @@ namespace Thrive
 		SetWindowAttributes(Common::APPLICATION_WIDTH , Common::APPLICATION_HEIGHT);
 	}
 
-	//Method		: Window::InitWindow()
-	//Parameters	: 
-	//Returns		: void
-	//Description   : This method is used to create our SFML window using our window attributes and creating a window with 
-	//					m_RenderWindow variable. 
+/**
+ * Method		: Window::InitWindow()
+ * Parameters	: 
+ * Returns		: void
+ * Description   : This method is used to create our SFML window using our window attributes and creating a window with 
+ * 				m_RenderWindow variable. 
+ */
 	void Window::InitWindow()
 	{
 		m_RenderWindow.create(
@@ -39,10 +41,12 @@ namespace Thrive
 		m_RenderWindow.setFramerateLimit(GetFrameRate()); //60fps 
 	}
 
-	//Method		: void Window::SetWindowAttributes(const unsigned int width, const unsigned int height, const std::string& name = "Thrive Engine")
-	//Parameters	: const unsigned int width, const unsigned int height, const std::string& name = "Thrive Engine"
-	//Returns		: void
-	//Description   : This method will be used to set our WindowAttributes. 
+/**
+ * Method		: void Window::SetWindowAttributes(const unsigned int width, const unsigned int height, const std::string& name = "Thrive Engine")
+ * Parameters	: const unsigned int width, const unsigned int height, const std::string& name = "Thrive Engine"
+ * Returns		: void
+ * Description   : This method will be used to set our WindowAttributes. 
+ */
 	void Window::SetWindowAttributes(const unsigned int width, const unsigned int height, const std::string& name)
 	{
 		m_WindowAttributes.height = height;
@@ -50,17 +54,21 @@ namespace Thrive
 		m_WindowAttributes.name = name;
 	} 
 
-	//Method		: void Window::PollEvents(const std::function<void(Event&)>& callback)
-	//Parameters	: const std::function<void(Event&)>& callback
-	//Returns		: void
-	//Description   : This method will be used to poll current incoming events. 
+/**
+ * Method		: void Window::PollEvents(const std::function<void(Event&)>& callback)
+ * Parameters	: const std::function<void(Event&)>& callback
+ * Returns		: void
+ * Description   : This method will be used to poll current incoming events. 
+ */
 	void Window::PollEvents(const std::function <void(Event&)>& callback)
 	{
 		while (const std::optional event = m_RenderWindow.pollEvent())
 		{
 			auto e = TranslateEvent(*event);
 
-			// Only dispatch valid events
+/**
+ * Only dispatch valid events
+ */
 			if (e)
 			{
 				callback(*e);
@@ -68,15 +76,19 @@ namespace Thrive
 		}
 	}
 
-	//Method		: std::unique_ptr<Event> Window::TranslateEvent(const sf::Event& e)
-	//Parameters	: (const sf::Event& e)
-	//Returns		: nullptr or The type of event that was just called. 
-	//Description   : This method will take an sf::Event and based off what the event is that is the event going to my event system. 
+/**
+ * Method		: std::unique_ptr<Event> Window::TranslateEvent(const sf::Event& e)
+ * Parameters	: (const sf::Event& e)
+ * Returns		: nullptr or The type of event that was just called. 
+ * Description   : This method will take an sf::Event and based off what the event is that is the event going to my event system. 
+ */
     std::unique_ptr<Event> Window::TranslateEvent(const sf::Event& e)
     {
-        // ============================
-        // INPUT SYSTEM HOOK 
-        // ============================
+/**
+ * ============================
+ * INPUT SYSTEM HOOK 
+ * ============================
+ */
         if (auto key = e.getIf<sf::Event::KeyPressed>())
         {
             Thrive::Input::SetKeyDown(

--- a/Engine/common/ThriveAssert.h
+++ b/Engine/common/ThriveAssert.h
@@ -3,15 +3,17 @@
 #include <iostream>
 #include <cstdlib>
 
-//Function		: ReportAssertionFailure (const char*, const char*, const char*, int, const char*)
-//Parameters    : 
-//                const char* expression,
-//                const char* message,
-//	              const char* file,
-//	              int line,
-//	              const char* function
-//Returns       : void
-//Description   : This function will take in an expression, and a message and print out all the information for the user. 
+/**
+ * Function		: ReportAssertionFailure (const char*, const char*, const char*, int, const char*)
+ * Parameters    : 
+ *                const char* expression,
+ *                const char* message,
+ *               const char* file,
+ *               int line,
+ *               const char* function
+ * Returns       : void
+ * Description   : This function will take in an expression, and a message and print out all the information for the user. 
+ */
 inline void ReportAssertionFailure(
 	const char* expression,
 	const char* message,
@@ -33,17 +35,21 @@ inline void ReportAssertionFailure(
 }
 
 
-//Change this right here based off your debug constant!!!!!!
-///
-///
-/// 
+/**
+ * Change this right here based off your debug constant!!!!!!
+ * /
+ * /
+ * / 
+ */
 #ifdef THRIVE_DEBUG
 
 	//Macro				: THRIVE_ASSERT
 	//Parameter         : (expr, msg)
 	//Description		: This macro will take in an expression and a string as a message. 
 	
-	//Change this constant name here!!!!
+/**
+ * Change this constant name here!!!!
+ */
 	#define THRIVE_ASSERT(expr, msg)									  \
 	 do                                                                   \
 		{                                                                 \

--- a/Engine/common/ThriveTime.cpp
+++ b/Engine/common/ThriveTime.cpp
@@ -18,58 +18,76 @@ namespace Thrive
 	float Time::s_TotalTime = 0.0f; 
 	float Time::s_TimeScale = 1.0f;
 
-	//Method		: Update
-	//Parameters	: ()
-	//Returns		: void
-	//Description   : This method will update our static Time class members. 
+/**
+ * Method		: Update
+ * Parameters	: ()
+ * Returns		: void
+ * Description   : This method will update our static Time class members. 
+ */
 	void Time::Update()
 	{
-		//Raw frame time
+/**
+ * Raw frame time
+ */
 		s_UnscaledDeltaTime = s_Clock.Restart();
 
-		//Apply time scaling
+/**
+ * Apply time scaling
+ */
 		s_DeltaTime = s_UnscaledDeltaTime * s_TimeScale;
 
-		//Accumulate total time (scaled) 
+/**
+ * Accumulate total time (scaled) 
+ */
 		s_TotalTime += s_DeltaTime;
 	}
 
-	//Method		: GetDeltaTime
-	//Parameters	: ()
-	//Returns		: float
-	//Description   : This method returns the delta time
+/**
+ * Method		: GetDeltaTime
+ * Parameters	: ()
+ * Returns		: float
+ * Description   : This method returns the delta time
+ */
 	float Time::GetDeltaTime() {
 		return s_DeltaTime; 
 	}
 
-	//Method		: GetUnscaledDeltaTime
-	//Parameters	: ()
-	//Returns		: float
-	//Description   : This method will return the unscaled delta time 
+/**
+ * Method		: GetUnscaledDeltaTime
+ * Parameters	: ()
+ * Returns		: float
+ * Description   : This method will return the unscaled delta time 
+ */
 	float Time::GetUnscaledDeltaTime() {
 		return s_UnscaledDeltaTime;
 	}
 
-	//Method		: GetTime
-	//Parameters	: ()'
-	//Returns		: float
-	//Description   : This method will return the total time
+/**
+ * Method		: GetTime
+ * Parameters	: ()'
+ * Returns		: float
+ * Description   : This method will return the total time
+ */
 	float Time::GetTime(){
 		return s_TotalTime; 
 	}
 
-	//Method		: SetTimeScales (float scales)
-	//Parameters	: (float scales)
-	//Returns		: void
-	//Description   : This method will set our time scale. 
+/**
+ * Method		: SetTimeScales (float scales)
+ * Parameters	: (float scales)
+ * Returns		: void
+ * Description   : This method will set our time scale. 
+ */
 	void Time::SetTimeScales(float scale) {
 		s_TimeScale = scale;
 	}
 
-	//Method		: GetTimeScale()
-	//Parameters	: ()
-	//Returns		: float
-	//Description   : This method will return the time scale. 
+/**
+ * Method		: GetTimeScale()
+ * Parameters	: ()
+ * Returns		: float
+ * Description   : This method will return the time scale. 
+ */
 	float Time::GetTimeScale() {
 		return s_TimeScale;
 	}

--- a/Engine/common/Tools/Log.h
+++ b/Engine/common/Tools/Log.h
@@ -12,7 +12,9 @@
 namespace Thrive
 {
 
-	//Change this path to the file you want.
+/**
+ * Change this path to the file you want.
+ */
 	const std::string k_FilePath = "../engine/log/engine.log"; 
 
 	/*
@@ -39,12 +41,16 @@ namespace Thrive
 		{
 			if (m_CoreLogger) return;
 
-			// Console sink
+/**
+ * Console sink
+ */
 			auto consoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
 
 			if (logFileActive) // Console and file 
 			{
-				// File sink 
+/**
+ * File sink 
+ */
 				auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(k_FilePath, true);
 
 				std::vector<spdlog::sink_ptr> sinks { consoleSink, fileSink };
@@ -133,7 +139,9 @@ namespace Thrive
 	#define LOG_CORE_CRITICAL(...) ::Thrive::Log::GetCoreLogger()->critical(__VA_ARGS__)
 
 #else
-	// Compile out logging completely
+/**
+ * Compile out logging completely
+ */
 	#define LOG_CORE_TRACE(...)
 	#define LOG_CORE_INFO(...)
 	#define LOG_CORE_WARN(...)

--- a/Engine/common/pch.h
+++ b/Engine/common/pch.h
@@ -1,7 +1,9 @@
 #pragma once
 
 
-// Standard library headers
+/**
+ * Standard library headers
+ */
 #include <iostream>
 #include <vector>
 #include <string>


### PR DESCRIPTION
## Summary

docs: convert leading // comments to Doxygen style

## Changes

- Engine\common\pch.h
- Engine\common\ThriveAssert.h
- Engine\common\ThriveTime.cpp
- Engine\common\Tools\Log.h
- Engine\Core\Application.cpp
- Engine\Core\Application.h
- Engine\Core\ImGuiLayer.cpp
- Engine\Core\ImGuiLayer.h
- Engine\Core\Layer.h
- Engine\Core\LayerStack.cpp
- Engine\Core\LayerStack.h
- Engine\Core\Window.cpp

Fixes #19
